### PR TITLE
Disable loading temporal-test-server

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5152,16 +5152,16 @@
         },
         {
             "name": "internal/dload",
-            "version": "1.2.0",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-internal/dload.git",
-                "reference": "3a5ef875696b52dd1cbd6366a99be0d31b68ec2b"
+                "reference": "b69df34461e4e407af6861298c26bedad58471dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-internal/dload/zipball/3a5ef875696b52dd1cbd6366a99be0d31b68ec2b",
-                "reference": "3a5ef875696b52dd1cbd6366a99be0d31b68ec2b",
+                "url": "https://api.github.com/repos/php-internal/dload/zipball/b69df34461e4e407af6861298c26bedad58471dd",
+                "reference": "b69df34461e4e407af6861298c26bedad58471dd",
                 "shasum": ""
             },
             "require": {
@@ -5211,7 +5211,7 @@
             ],
             "support": {
                 "issues": "https://github.com/php-internal/dload/issues",
-                "source": "https://github.com/php-internal/dload/tree/1.2.0"
+                "source": "https://github.com/php-internal/dload/tree/1.2.2"
             },
             "funding": [
                 {
@@ -5219,7 +5219,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2025-06-03T18:56:58+00:00"
+            "time": "2025-06-12T07:03:13+00:00"
         },
         {
             "name": "kelunik/certificate",

--- a/dload.xml
+++ b/dload.xml
@@ -5,7 +5,7 @@
     <actions>
         <download software="rr" version="^2025.1.1"/>
         <download software="temporal" version="^1.3"/>
-        <download software="temporal-tests-server"/>
+        <!--<download software="temporal-tests-server"/>-->
     </actions>
     <registry>
         <software name="Temporal Tests Server" alias="temporal-tests-server">


### PR DESCRIPTION
## What was changed

- Update dload package version to 1.2.2 
- Disable loading temporal-test-server

## Why?

dload v1.2.2 suppresses deprecation notices;
temporal-test-server is not provided for ARM and it's might be a problem
